### PR TITLE
Fixing this.$root.$on function calls, with attendant noise from my setup

### DIFF
--- a/labshare-client/src/components/HelperForm.vue
+++ b/labshare-client/src/components/HelperForm.vue
@@ -173,7 +173,7 @@ export default {
       })
     }
     else {
-      this.$root.on('gotPtofile', () => {
+      this.$root.$on('gotProfile', () => {
         this.formData = this.$user;
         this.$nextTick(() => {
           this.disableSubmit = this.$el.querySelectorAll(".is-invalid").length > 0;

--- a/labshare-client/src/components/LabForm.vue
+++ b/labshare-client/src/components/LabForm.vue
@@ -127,7 +127,7 @@ export default {
       })
     }
     else {
-      this.$root.on('gotPtofile', () => {
+      this.$root.$on('gotProfile', () => {
         this.formData = this.$user;
         this.$nextTick(() => {
           this.disableSubmit = this.$el.querySelectorAll(".is-invalid").length > 0;


### PR DESCRIPTION
Getting this error:

![image](https://user-images.githubusercontent.com/9030612/78461436-29cc9980-76c9-11ea-85d4-f566dff0f769.png)

This PR fixes the calls to `this.$root.$on`, though there is a lot of noise introduced by my VSCode auto-formatting. We can probably fix that with Prettier and linting rules, but that's dev-experience sugar.